### PR TITLE
add:ログイン後にユーザーの情報をstoreにuidを紐付けて送信できるようにした

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -1,24 +1,49 @@
-import { Routes, Route } from "react-router-dom"
-import { getAuth, onAuthStateChanged } from "firebase/auth"
+import { Routes, Route } from "react-router-dom";
+import { useEffect, useState } from "react";
 
-import { HomePage } from "../atomicDesign/pages/HomePage"
-import { MylistPage } from "../atomicDesign/pages/MylistPage"
-import { GoalPage } from "../atomicDesign/pages/GoalPage"
-import { StatsPage } from "../atomicDesign/pages/StatsPage"
-import { AccountPage } from "../atomicDesign/pages/AccountPage"
-import { Page404 } from "../atomicDesign/pages/Page404"
-import { StartPage } from "../atomicDesign/pages/StartPage"
-import { useEffect, useState } from "react"
+import { getAuth, onAuthStateChanged } from "firebase/auth";
+import { setDoc, collection, Timestamp, doc } from "firebase/firestore";
+import { db } from "../firebase/firebase";
 
+import { HomePage } from "../atomicDesign/pages/HomePage";
+import { MylistPage } from "../atomicDesign/pages/MylistPage";
+import { GoalPage } from "../atomicDesign/pages/GoalPage";
+import { StatsPage } from "../atomicDesign/pages/StatsPage";
+import { AccountPage } from "../atomicDesign/pages/AccountPage";
+import { Page404 } from "../atomicDesign/pages/Page404";
+import { StartPage } from "../atomicDesign/pages/StartPage";
+
+// --------------------------現在の問題点----------------------------
+// 毎回処理が走るたびに、setDocでcollectionにユーザーの情報を追加する処理が走る
+// だが、これはいらない動作なので、ユーザー情報を追加する処理は一回だけ行うようにしたい(無駄な処理を減らすため)
+// ----------------------------------------------------------------
+// --------------------------次にしたいこと----------------------------
+// ・ ログイン成功後に、homeに飛ぶようにする（リダイレクトを行う）
+// ・ ログアウト
+// ・ 上の問題点の解決
+// ・ todosとuserの情報を紐付けして、ログイン後にtodosの作成者todosの情報を取得する処理
+// ----------------------------------------------------------------
 const PrivateRoute = () => {
-  // 認証状態で振り分け
-  const auth = getAuth()
-  const user = auth.currentUser
+  const auth = getAuth();
+  const user = auth.currentUser;
+  const collectionRef = collection(db ,"users");
   if (user !== null) {
+    // collectionに渡したい値を設定
+    const displayName = user.displayName;
+    const email = user.email;
+    const photoURL = user.photoURL;
     const uid = user.uid
-    console.log("現在サインイン状態")
-    console.log("user=" + user)
-    console.log("uid=" + uid)
+
+    const newDoclist = {
+      displayName: displayName,
+      email: email,
+      photoURL: photoURL,
+      uid: uid,
+      createdAt: Timestamp.now()
+    };
+    // collectionRefにnewDoclist(自動IDはuidに設定)を追加
+    setDoc(doc(collectionRef, uid), {...newDoclist});
+    console.log("サインインしました")
     return (
       <Routes>
         <Route path="/signin" element={<StartPage />} />
@@ -31,8 +56,7 @@ const PrivateRoute = () => {
       </Routes>
     )
   } else {
-    console.log("サインインしてください！！")
-    console.log(user)
+    console.log("サインインできていません");
     return (
       <Routes>
         <Route path="/signin" element={< StartPage />} />
@@ -49,14 +73,13 @@ export default function App() {
   useEffect(() => {
     onAuthStateChanged(auth, (user) => {
       if (user) {
-        console.log(user)
         setSigninUser(user)
       }
     })
-  }, [])
+  }, [signinUser])
 
   return (
-    < div className="App" >
+    <div className="App" >
       <PrivateRoute />
     </div >
   )


### PR DESCRIPTION
### 現在の問題点
 毎回処理が走るたびに、setDocでcollectionにユーザーの情報を追加する処理が走る
 だが、これはいらない動作なので、ユーザー情報を追加する処理は一回だけ行うようにしたい(無駄な処理を減らすため)

### 次にしたいこと
・ ログイン成功後に、homeに飛ぶようにする（リダイレクトを行う）
・ ログアウト
・ 上の問題点の解決
・ todosとuserの情報を紐付けして、ログイン後にtodosの作成者todosの情報を取得する処理